### PR TITLE
Add license to output of pip show

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 readme = "pypi/README.md"
+license = "Apache-2.0"
 packages = [
     { include = "timer_cli" }
 ]


### PR DESCRIPTION
This PR adds license info to the output of the `pip show globus-timer-cli` (or if using pipx: `pipx runpip globus-timer-cli show globus-timer-cli`) command:

Before:
```
Name: globus-timer-cli
Version: 0.2.5
Summary: CLI for interacting with the timer API
Home-page: None
Author: Rudyard Richter
Author-email: rudyard@globus.org
License: None
Location: /Users/uriel/.local/pipx/venvs/globus-timer-cli/lib/python3.9/site-packages
Requires: requests, importlib-metadata, globus-sdk, click
Required-by:
```

After:
```
Name: globus-timer-cli
Version: 0.2.5
Summary: CLI for interacting with the timer API
Home-page: None
Author: Rudyard Richter
Author-email: rudyard@globus.org
License: Apache-2.0
Location: /Users/uriel/.local/pipx/venvs/globus-timer-cli/lib/python3.9/site-packages
Requires: requests, importlib-metadata, globus-sdk, click
Required-by:
```
